### PR TITLE
Add the default locale to the list of locales

### DIFF
--- a/bundles/translation-form/index.html
+++ b/bundles/translation-form/index.html
@@ -104,7 +104,7 @@ new A2lix\TranslationFormBundle\A2lixTranslationFormBundle(),
 # app/config/config.yml
 a2lix_translation_form:
     locale_provider: default       # [1]
-    locales: [fr, es, de]          # [1-a]
+    locales: [en, fr, es, de]          # [1-a]
     default_locale: en             # [1-b]
     required_locales: [fr]         # [1-c]
     manager_registry: doctrine      # [2]


### PR DESCRIPTION
I got the error `Default locale should be contained in locales` when using the suggested `config.yml` contents.