### PR TITLE
Fix typo on exclude_fields to 2.x branch

### DIFF
--- a/bundles/translation-form/2.x.html
+++ b/bundles/translation-form/2.x.html
@@ -156,7 +156,7 @@ $builder->add('translations', 'a2lix_translations', array(
             )
         )
     ),
-    'excluded_fields' => array('details')            // [2]
+    'exclude_fields' => array('details')            // [2]
 ));
 {% endhighlight %}
 


### PR DESCRIPTION
On master branch it is `excluded_fields` but on 2.x it is `exclude_fields`

Closes #19 
Closes https://github.com/a2lix/TranslationFormBundle/issues/264